### PR TITLE
Add ability scores to character model

### DIFF
--- a/db/migrate/20210519200800_add_stats_to_characters.rb
+++ b/db/migrate/20210519200800_add_stats_to_characters.rb
@@ -1,0 +1,10 @@
+class AddStatsToCharacters < ActiveRecord::Migration[6.1]
+  def change
+    add_column :characters, :str, :integer, default: 0
+    add_column :characters, :dex, :integer, default: 0
+    add_column :characters, :con, :integer, default: 0
+    add_column :characters, :int, :integer, default: 0
+    add_column :characters, :wis, :integer, default: 0
+    add_column :characters, :chr, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_28_180703) do
+ActiveRecord::Schema.define(version: 2021_05_19_200800) do
 
   create_table "characters", force: :cascade do |t|
     t.string "name", limit: 32, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "user_id"
+    t.integer "str", default: 0
+    t.integer "dex", default: 0
+    t.integer "con", default: 0
+    t.integer "int", default: 0
+    t.integer "wis", default: 0
+    t.integer "chr", default: 0
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Added a migration that will add the database columns for ability scores. Just need to run a `rails db:migrate` after merging this to update the schema

Resolves #44